### PR TITLE
Fast C implementation of safeEq

### DIFF
--- a/c_impl/misc.c
+++ b/c_impl/misc.c
@@ -1,0 +1,7 @@
+/* Fast C implementation of a safe string equality test. */
+int c_safeEq(char *x, char *y, int length) {
+    int ret = 0, i;
+    for (i = 0; i < length; i++)
+        ret = ret | x[i] ^ y[i];
+    return ret;
+}

--- a/c_impl/misc.h
+++ b/c_impl/misc.h
@@ -1,0 +1,4 @@
+#ifndef CRYPTO_API_MISC_H
+#define CRYPTO_API_MISC_H
+int c_safeEq(char *x, char *y, int length);
+#endif

--- a/crypto-api.cabal
+++ b/crypto-api.cabal
@@ -24,6 +24,9 @@ stability:      stable
 build-type:     Simple
 cabal-version:  >= 1.6
 tested-with:    GHC == 7.0.3
+extra-source-files:
+  c_impl/misc.c
+  c_impl/misc.h
 
 
 Library
@@ -36,6 +39,8 @@ Library
   hs-source-dirs:
   exposed-modules: Crypto.Classes, Crypto.Types, Crypto.HMAC, Crypto.Modes, Crypto.Random, Crypto.Padding
   other-modules: Crypto.Util, Crypto.CPoly
+  extensions: ForeignFunctionInterface
+  c-sources: c_impl/misc.c
 
 source-repository head
   type:     git


### PR DESCRIPTION
On my computer, the C implementation is 1.6x faster for 32-byte strings and 24x faster for 10-kbyte strings.

Sorry about the whitespace changes, I still don't know how to deal with them in git.
