### PR TITLE
Export the non-IO key generators again.

### DIFF
--- a/Crypto/Classes.hs
+++ b/Crypto/Classes.hs
@@ -23,12 +23,16 @@ module Crypto.Classes
         , blockSizeBytes
         , keyLengthBytes
         , buildKeyIO
+        , buildKeyGen
         , StreamCipher(..)
         , buildStreamKeyIO
+        , buildStreamKeyGen
         , AsymCipher(..)
         , buildKeyPairIO
+        , buildKeyPairGen
         , Signing(..)
         , buildSigningKeyPairIO
+        , buildSigningKeyPairGen
         -- * Misc helper functions
         , encode
         , incIV


### PR DESCRIPTION
These exports were removed for some reason?
