### PR TITLE
stop using reproxy.

### DIFF
--- a/Crypto/Modes.hs
+++ b/Crypto/Modes.hs
@@ -541,10 +541,10 @@ getIVIO = do
 {-# INLINEABLE getIVIO #-}
 
 ivProxy :: Proxy k -> Proxy (IV k)
-ivProxy = reproxy
+ivProxy = const Proxy
 
 deIVProxy :: Proxy (IV k) -> Proxy k
-deIVProxy = reproxy
+deIVProxy = const Proxy
 
 proxyOf :: a -> Proxy a
 proxyOf = const Proxy


### PR DESCRIPTION
GHC 7.8 provides Data.Proxy and "tagged" will stop exporting
its Data.Proxy. Unfortunately, GHC 7.8's Data.Proxy does not
have "reproxy". This patch fixes this problem.
