### PR TITLE
Update references to System.Crypto.Random to point to System.Entropy

### DIFF
--- a/Crypto/Classes.hs
+++ b/Crypto/Classes.hs
@@ -320,7 +320,7 @@ getIV g =
                         | otherwise             -> Left (GenErrorOther "Generator failed to provide requested number of bytes")
 {-# INLINEABLE getIV #-}
 
--- | Obtain an 'IV' using the system entropy (see 'System.Crypto.Random')
+-- | Obtain an 'IV' using the system entropy (see 'System.Entropy')
 getIVIO :: (BlockCipher k) => IO (IV k)
 getIVIO = do
         let p = Proxy
@@ -459,7 +459,7 @@ blockSizeBytes = fmap (`div` 8) blockSize
 keyLengthBytes :: (BlockCipher k) => Tagged k ByteLength
 keyLengthBytes = fmap (`div` 8) keyLength
 
--- |Build a symmetric key using the system entropy (see 'System.Crypto.Random')
+-- |Build a symmetric key using the system entropy (see 'System.Entropy')
 buildKeyIO :: (BlockCipher k) => IO k
 buildKeyIO = buildKeyM getEntropy fail
 

--- a/Crypto/Random.hs
+++ b/Crypto/Random.hs
@@ -9,7 +9,7 @@
  This module is for instantiating cryptographicly strong
 determinitic random bit generators (DRBGs, aka PRNGs) For the simple
 use case of using the system random number generator
-('System.Crypto.Random') to seed the DRBG:
+('System.Entropy') to seed the DRBG:
 
 @   g <- newGenIO
 @
@@ -160,7 +160,7 @@ class CryptoRandomGen g where
         -- (`NotEnoughEntropy`).
         reseed          :: B.ByteString -> g -> Either GenError g
 
-        -- |By default this uses "System.Crypto.Random" to obtain
+        -- |By default this uses "System.Entropy" to obtain
         -- entropy for `newGen`.
         newGenIO :: IO g
         newGenIO = go 0


### PR DESCRIPTION
The documentation still points to System.Crypto.Random which is now gone and replaced by System.Entropy.
