### PR TITLE
Catch unreasonably large seeds with NeedsInfiniteSeed

### DIFF
--- a/Crypto/Random.hs
+++ b/Crypto/Random.hs
@@ -226,10 +226,15 @@ instance CryptoRandomGen SystemRandom where
 -- package.
 splitGen :: CryptoRandomGen g => g -> Either GenError (g,g)
 splitGen g =
-  let e = genBytes (genSeedLength `for` g) g
+  let e = genBytes' (genSeedLength `for` g) g
   in case e of
     Left e -> Left e
     Right (ent,g') -> 
        case newGen ent of
                 Right new -> Right (g',new)
                 Left e -> Left e
+  where
+  genBytes' seedLength g
+    | seedLength < 0      = Left NeedsInfiniteSeed
+    | seedLength > (2^30) = Left NeedsInfiniteSeed
+    | otherwise           = genBytes seedLength g


### PR DESCRIPTION
Apropos of https://github.com/TomMD/DRBG/issues/6

A possible hack that improves the error message: consider 1GB+ seeds as infinite.

I haven't compied it as the repo is missing `Crypto/Modes.hs-boot`, so wouldn't be surprised if it doesn't work as-is.
